### PR TITLE
chore: use gatsby clean instead of rimraf

### DIFF
--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -12,7 +12,7 @@
     "node": ">=8.0.0 <11.0.0"
   },
   "scripts": {
-    "clean": "rimraf .cache public",
+    "clean": "gatsby clean",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "build": "gatsby build",
@@ -51,7 +51,6 @@
     "prettier": "^1.15.3",
     "ptz-i18n": "^1.0.0",
     "react-intl": "^3.6.2",
-    "rimraf": "^2.6.3",
     "start-server-and-test": "^1.10.6"
   }
 }


### PR DESCRIPTION
- make use of `gatsby clean` command instead of `rimraf` 