### PR TITLE
Update `gatsby-plugin-react-axe` version

### DIFF
--- a/gatsby/gatsby-browser.js
+++ b/gatsby/gatsby-browser.js
@@ -1,9 +1,25 @@
-module.exports = {
-	onClientEntry: () => {
-		try {
-		  require('uswds_polyfills');
-		} catch (e) {
-		  // do nothing
-		}
-	}
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export const onClientEntry = () => {
+  try {
+    require('uswds_polyfills');
+  } catch (e) {
+    // do nothing
+  }
+};
+
+// Can re-install gatsby-plugin-react-axe on updated publish
+// https://github.com/angeloashmore/gatsby-plugin-react-axe/pull/1
+export const onInitialClientRender = async (_, pluginOptions = {}) => {
+  const { showInProduction, axeOptions } = {
+    showInProduction: false,
+    axeOptions: {},
+    ...pluginOptions,
+  };
+
+  if (process.env.NODE_ENV === 'development' || showInProduction) {
+    const { default: axe } = await import('react-axe');
+    axe(React, ReactDOM, 1000, axeOptions);
+  }
 };

--- a/gatsby/gatsby-browser.js
+++ b/gatsby/gatsby-browser.js
@@ -1,25 +1,7 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-
 export const onClientEntry = () => {
   try {
     require('uswds_polyfills');
   } catch (e) {
     // do nothing
-  }
-};
-
-// Can re-install gatsby-plugin-react-axe on updated publish
-// https://github.com/angeloashmore/gatsby-plugin-react-axe/pull/1
-export const onInitialClientRender = async (_, pluginOptions = {}) => {
-  const { showInProduction, axeOptions } = {
-    showInProduction: false,
-    axeOptions: {},
-    ...pluginOptions,
-  };
-
-  if (process.env.NODE_ENV === 'development' || showInProduction) {
-    const { default: axe } = await import('react-axe');
-    axe(React, ReactDOM, 1000, axeOptions);
   }
 };

--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -32,6 +32,7 @@ module.exports = {
     `gatsby-transformer-yaml`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
+    'gatsby-plugin-react-axe',
     `gatsby-plugin-react-helmet`,
     {
       resolve: 'gatsby-plugin-i18n',

--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -32,7 +32,6 @@ module.exports = {
     `gatsby-transformer-yaml`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
-    'gatsby-plugin-react-axe',
     `gatsby-plugin-react-helmet`,
     {
       resolve: 'gatsby-plugin-i18n',

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -26,6 +26,7 @@
     "gatsby": "^2.13.35",
     "gatsby-image": "^2.2.7",
     "gatsby-plugin-i18n": "^1.0.1",
+    "gatsby-plugin-react-axe": "^0.3.0",
     "gatsby-plugin-react-helmet": "^3.1.15",
     "gatsby-plugin-sharp": "^2.2.9",
     "gatsby-source-filesystem": "^2.1.6",

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -26,7 +26,6 @@
     "gatsby": "^2.13.35",
     "gatsby-image": "^2.2.7",
     "gatsby-plugin-i18n": "^1.0.1",
-    "gatsby-plugin-react-axe": "^0.2.2",
     "gatsby-plugin-react-helmet": "^3.1.15",
     "gatsby-plugin-sharp": "^2.2.9",
     "gatsby-source-filesystem": "^2.1.6",

--- a/gatsby/yarn.lock
+++ b/gatsby/yarn.lock
@@ -2208,7 +2208,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^3.4.0:
+axe-core@^3.3.2, axe-core@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.0.tgz#a57ee620c182d5389aff229586aaae06bc541abe"
   integrity sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==
@@ -5989,6 +5989,13 @@ gatsby-plugin-page-creator@^2.1.31:
     glob "^7.1.6"
     lodash "^4.17.15"
     micromatch "^3.1.10"
+
+gatsby-plugin-react-axe@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-axe/-/gatsby-plugin-react-axe-0.3.0.tgz#5ee31a4b70ebd757025268e53dcb6c8514b53aad"
+  integrity sha512-ZKygR3YHfdea6Muo/44tZx8lCzMEMVWU4TF6ahhxmQoS1qB9TWw8z2+WB5C/UPOWqy/cNwBcoDzad6ETKWvdpQ==
+  dependencies:
+    react-axe "^3.0.2"
 
 gatsby-plugin-react-helmet@^3.1.15:
   version "3.1.15"
@@ -11549,6 +11556,14 @@ react-aria-menubutton@^6.0.0:
     prop-types "^15.6.0"
     teeny-tap "^0.2.0"
 
+react-axe@^3.0.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.3.0.tgz#b87bff644ed3ed6f1ca12bcc64c00000e359c25b"
+  integrity sha512-JoxU2jcTla37U6MtqIoYnGaRQcAHkNm9JxTjx2wcEgFm8Zd2A2vo9eboxcmpLjklXDKJwJNbyDo2Jcbbme6xwA==
+  dependencies:
+    axe-core "^3.3.2"
+    requestidlecallback "^0.3.0"
+
 react-datetime@^2.16.3:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.16.3.tgz#7f9ac7d4014a939c11c761d0c22d1fb506cb505e"
@@ -12415,6 +12430,11 @@ request@2.88.0, request@^2.83.0, request@^2.88.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"

--- a/gatsby/yarn.lock
+++ b/gatsby/yarn.lock
@@ -2208,7 +2208,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^3.3.2, axe-core@^3.4.0:
+axe-core@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.0.tgz#a57ee620c182d5389aff229586aaae06bc541abe"
   integrity sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==
@@ -5989,13 +5989,6 @@ gatsby-plugin-page-creator@^2.1.31:
     glob "^7.1.6"
     lodash "^4.17.15"
     micromatch "^3.1.10"
-
-gatsby-plugin-react-axe@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-axe/-/gatsby-plugin-react-axe-0.2.2.tgz#c3076b2f1faf4947c7e8a0d9c5cfd3869c8a26e2"
-  integrity sha512-eV8XuWnhUnSoT7bPq1iXzUipBdwnVjN1GWWIUNYtKnDX/Z90EmU8wp+zbSa9XIV9/EODcm+xH600SunYXVuzBw==
-  dependencies:
-    react-axe "^3.0.2"
 
 gatsby-plugin-react-helmet@^3.1.15:
   version "3.1.15"
@@ -11556,14 +11549,6 @@ react-aria-menubutton@^6.0.0:
     prop-types "^15.6.0"
     teeny-tap "^0.2.0"
 
-react-axe@^3.0.2:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.3.0.tgz#b87bff644ed3ed6f1ca12bcc64c00000e359c25b"
-  integrity sha512-JoxU2jcTla37U6MtqIoYnGaRQcAHkNm9JxTjx2wcEgFm8Zd2A2vo9eboxcmpLjklXDKJwJNbyDo2Jcbbme6xwA==
-  dependencies:
-    axe-core "^3.3.2"
-    requestidlecallback "^0.3.0"
-
 react-datetime@^2.16.3:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.16.3.tgz#7f9ac7d4014a939c11c761d0c22d1fb506cb505e"
@@ -12430,11 +12415,6 @@ request@2.88.0, request@^2.83.0, request@^2.88.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
-
-requestidlecallback@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
-  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
# Purpose

~The `gatsby-plugin-react-axe` plugin relies on a Gatsby hook that runs the audit before the app is fully mounted on the client, resulting in accidental false positives.~

~I've opened a PR to the plugin repo to change the hook, in the meantime, pulling the audit code directly into the project's `gatsby-browser` file.~

PR merged (angeloashmore/gatsby-plugin-react-axe#1), update published. This PR updates the package version.