### PR TITLE
Limit the number of events visible on the homepage

### DIFF
--- a/gatsby/src/components/index.js
+++ b/gatsby/src/components/index.js
@@ -30,6 +30,7 @@ const propTypes = {
   news: PropTypes.array,
   content: PropTypes.object,
   heroImg: PropTypes.object,
+  events: PropTypes.object,
 };
 
 const Index = ({
@@ -40,6 +41,7 @@ const Index = ({
   images,
   communityImgs,
   mapImg,
+  events,
   ...rest
 }) => {
   const { callout, media, section, tagline, layout } = content;
@@ -65,7 +67,7 @@ const Index = ({
 
         <Communities imgs={communityImgs} mapImg={mapImg} />
 
-        <NewsAndEvents layout={layout} news={news} />
+        <NewsAndEvents layout={layout} news={news} events={events} />
       </Layout>
     </>
   );

--- a/gatsby/src/components/index/NewsAndEvents.js
+++ b/gatsby/src/components/index/NewsAndEvents.js
@@ -37,8 +37,9 @@ const renderMonth = (month, news) => {
   );
 };
 
-export default function NewsAndEvents({ layout, news }) {
-  const newsByMonth = _.groupBy(news, newsItem =>
+export default function NewsAndEvents({ layout, news, events }) {
+  const recentNews = _.takeRight(news, events.defaultVisible);
+  const newsByMonth = _.groupBy(recentNews, newsItem =>
     moment(newsItem.frontmatter.date).format("MMMM YYYY")
   );
 

--- a/gatsby/src/data/siteMetadata.js
+++ b/gatsby/src/data/siteMetadata.js
@@ -10,6 +10,9 @@ module.exports = {
       { text: 'Tiếng Việt', link: '/vt' },
     ],
   },
+  events: {
+    defaultVisible: 5,
+  },
   //   siteUrl: 'https://angeloocana.com',
   //   author: {
   //     name: 'Ângelo Ocanã',

--- a/gatsby/src/templates/index.js
+++ b/gatsby/src/templates/index.js
@@ -26,6 +26,7 @@ const IndexTemplate = ({ location, uri, data, ...rest }) => {
         student: data.student.childImageSharp.fluid,
       }}
       mapImg={data.mapImg.childImageSharp}
+      events={data.site.siteMetadata.events}
       {...rest}
     />
   );
@@ -33,6 +34,13 @@ const IndexTemplate = ({ location, uri, data, ...rest }) => {
 
 export const query = graphql`
   query IndexByLang($lang: String) {
+    site {
+      siteMetadata {
+        events {
+          defaultVisible
+        }
+      }
+    }
     image1: file(base: { eq: "Diversity-min.jpg" }) {
       childImageSharp {
         fluid(maxHeight: 1000) {


### PR DESCRIPTION
Limits events to a current default of 5 most recent, configurable via the siteMetadata.