### PR TITLE
[WIP] Fix screen-reader bug

### DIFF
--- a/gatsby/src/components/index/NewsAndEvents.js
+++ b/gatsby/src/components/index/NewsAndEvents.js
@@ -108,6 +108,7 @@ const NewsAndEvents = ({ data, language }) => {
           <div className="grid-col-12 tablet:grid-col-6 tablet:padding-right-2">
             <div className="grid-col">
               <h2 className="font-heading-xl margin-top-0 tablet:margin-bottom-0 text-center">
+                <span style={{visibility: 'hidden'}}>Events</span>
                 <div>
                   <Icon path={mdiCalendarStar} title="Events" size={2.5} />
                 </div>
@@ -122,6 +123,7 @@ const NewsAndEvents = ({ data, language }) => {
             <div className="grid-row grid-gap">
               <div className="grid-col">
                 <h2 className="font-heading-xl margin-top-0 tablet:margin-bottom-0 text-center">
+                  <span style={{visibility: 'hidden'}}>{newsTitle}</span>
                   <div>
                     <Icon path={mdiNewspaper} title="News Story" size={2.5} />
                   </div>

--- a/gatsby/src/components/index/NewsAndEvents.js
+++ b/gatsby/src/components/index/NewsAndEvents.js
@@ -108,7 +108,6 @@ const NewsAndEvents = ({ data, language }) => {
           <div className="grid-col-12 tablet:grid-col-6 tablet:padding-right-2">
             <div className="grid-col">
               <h2 className="font-heading-xl margin-top-0 tablet:margin-bottom-0 text-center">
-                <span style={{visibility: 'hidden'}}>Events</span>
                 <div>
                   <Icon path={mdiCalendarStar} title="Events" size={2.5} />
                 </div>
@@ -123,9 +122,8 @@ const NewsAndEvents = ({ data, language }) => {
             <div className="grid-row grid-gap">
               <div className="grid-col">
                 <h2 className="font-heading-xl margin-top-0 tablet:margin-bottom-0 text-center">
-                  <span style={{visibility: 'hidden'}}>{newsTitle}</span>
                   <div>
-                    <Icon path={mdiNewspaper} title="News Story" size={2.5} />
+                    <Icon path={mdiNewspaper} title={newsTitle} size={2.5} />
                   </div>
                   {newsTitle}
                 </h2>


### PR DESCRIPTION
#73 

I used Chrome's [ChromeVox extension](https://chrome.google.com/webstore/detail/chromevox-classic-extensi/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en) to read the page to me. It actually read "Events" and "Recent News", albeit very quickly, so I'm not sure what to change about this.

I read [here](http://haltersweb.github.io/Accessibility/testing-icon-labeling.html) that some browsers may not support reading SVG titles; we could try using hidden spans to work around that, e.g.:
```html
<span style={{visibility: 'hidden'}}>Events</span>
```

ChromeVox actually ignores the hidden spans, but reads the SVG title and the visible `Events`/`{newsTitle}` lines. On the other hand, Chrome's built-in "Edit" -> "Speech" -> "Start Speaking" feature reads the hidden spans, but ignores the SVG titles. Go figure.

In any case, I think we need more info regarding the conditions under which this fails in order to proceed with addressing this.